### PR TITLE
Added HEADER_CHECKS configuration option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN        true && \
 COPY       supervisord.conf /etc/supervisord.conf
 COPY       rsyslog.conf /etc/rsyslog.conf
 COPY       opendkim.conf /etc/opendkim/opendkim.conf
+COPY       header_checks /etc/header_checks
 COPY       run.sh /run.sh
 COPY       opendkim.sh /opendkim.sh
 RUN        chmod +x /run.sh /opendkim.sh

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Example:
 docker run --rm --name postfix -e "ALLOWED_SENDER_DOMAINS=example.com example.org" -e "MASQUERADED_DOMAINS=example.com" -p 1587:587 boky/postfix
 ```
 
+### `HEADER_CHECKS`
+
+Each message header line is compared against a pre-configured list of patterns. When a match is found the corresponding action is executed. Set to a non-empty string (usually "1" or "yes") enable.
+
 ## `DKIM`
 
 **This image is equiped with support for DKIM.** If you want to use DKIM you will need to generate DKIM keys yourself. 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,12 @@ docker run --rm --name postfix -e "ALLOWED_SENDER_DOMAINS=example.com example.or
 
 ### `HEADER_CHECKS`
 
-Each message header line is compared against a pre-configured list of patterns. When a match is found the corresponding action is executed. Set to a non-empty string (usually "1" or "yes") enable.
+Each message header line is compared against a pre-configured list of patterns. When a match is found the corresponding action is executed. The default patterns can be found in the `header_checks` file. Simply append new or delete unwanted patterns. Set to a non-empty string (usually "1" or "yes") to enable.
+
+Example:
+```
+docker run --rm --name postfix -e "HEADER_CHECKS="yes" example.org" -p 1587:587 boky/postfix
+```
 
 ## `DKIM`
 

--- a/header_checks
+++ b/header_checks
@@ -1,0 +1,11 @@
+# Sample For Dropping Headers: 	
+#/^Header: IfContains/ 	      IGNORE
+/^Received:.*with ESMTPSA/    IGNORE
+/^Received:.*with ESMTPS/     IGNORE
+/^Received:.*with SMTP/       IGNORE
+/^Received:/ 	              IGNORE
+/^X-Originating-IP:/          IGNORE
+/^X-Mailer:/                  IGNORE
+/^X-PHP-Originating-Script:/  IGNORE
+/^User-Agent:/                IGNORE
+/^Mime-Version:/              REPLACE Mime-Version: 1.0

--- a/header_checks
+++ b/header_checks
@@ -1,9 +1,9 @@
 # Sample For Dropping Headers: 	
-#/^Header: IfContains/ 	      IGNORE
+#/^Header: IfContains/        IGNORE
 /^Received:.*with ESMTPSA/    IGNORE
 /^Received:.*with ESMTPS/     IGNORE
 /^Received:.*with SMTP/       IGNORE
-/^Received:/ 	              IGNORE
+/^Received:/                  IGNORE
 /^X-Originating-IP:/          IGNORE
 /^X-Mailer:/                  IGNORE
 /^X-PHP-Originating-Script:/  IGNORE

--- a/run.sh
+++ b/run.sh
@@ -195,14 +195,14 @@ else
 fi
 
 if [ ! -z "$MASQUERADED_DOMAINS" ]; then
-        echo -e "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
-        postconf -e "masquerade_domains = $MASQUERADED_DOMAINS"
-        postconf -e "local_header_rewrite_clients = static:all"
+		echo -e "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
+		postconf -e "masquerade_domains = $MASQUERADED_DOMAINS"
+		postconf -e "local_header_rewrite_clients = static:all"
 fi
 
 if [ ! -z "$HEADER_CHECKS" ]; then
-		echo -e "‣ $notice Setting header_checks"
-		postconf -e smtp_header_checks="regexp:/etc/header_checks"
+		echo -e "‣ $notice Setting up header_checks"
+		postconf -e "smtp_header_checks=regexp:/etc/header_checks"
 		
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -195,15 +195,14 @@ else
 fi
 
 if [ ! -z "$MASQUERADED_DOMAINS" ]; then
-		echo -e "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
-		postconf -e "masquerade_domains = $MASQUERADED_DOMAINS"
-		postconf -e "local_header_rewrite_clients = static:all"
+	echo -e "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
+	postconf -e "masquerade_domains = $MASQUERADED_DOMAINS"
+	postconf -e "local_header_rewrite_clients = static:all"
 fi
 
 if [ ! -z "$HEADER_CHECKS" ]; then
-		echo -e "‣ $notice Setting up header_checks"
-		postconf -e "smtp_header_checks=regexp:/etc/header_checks"
-		
+	echo -e "‣ $notice Setting up header_checks"
+	postconf -e "smtp_header_checks=regexp:/etc/header_checks"
 fi
 
 DKIM_ENABLED=

--- a/run.sh
+++ b/run.sh
@@ -195,9 +195,15 @@ else
 fi
 
 if [ ! -z "$MASQUERADED_DOMAINS" ]; then
-        echo -en "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
+        echo -e "‣ $notice Setting up address masquerading: ${emphasis}$MASQUERADED_DOMAINS${reset}"
         postconf -e "masquerade_domains = $MASQUERADED_DOMAINS"
         postconf -e "local_header_rewrite_clients = static:all"
+fi
+
+if [ ! -z "$HEADER_CHECKS" ]; then
+		echo -e "‣ $notice Setting header_checks"
+		postconf -e smtp_header_checks="regexp:/etc/header_checks"
+		
 fi
 
 DKIM_ENABLED=


### PR DESCRIPTION
## Description

I added the HEADER_CHECKS [1] option with a sample configuration.

Each message header line is compared against a pre-configured list of patterns. When a match is found the corresponding action is executed.


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have tested this version of the docker image in a flask application and checked if the headers where ignored or replaced.


[1]: http://www.postfix.org/header_checks.5.html