### PR TITLE
Allow setting empty ALLOWED_SENDER_DOMAINS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV RELAYHOST_TLS_LEVEL=
 ENV MYNETWORKS=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 # Allow any sender domains
 ENV ALLOWED_SENDER_DOMAINS=
+# Don't allow blank value for ALLOWED_SENDER_DOMAINS
+ENV ALLOW_EMPTY_SENDER_DOMAINS=
 # Attachments size. 0 means unlimited. Usually needs to be set if your relay host has an attachment size limit
 ENV MESSAGE_SIZE_LIMIT=
 # Enable additional debugging for connections to postfix

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $RELAYHOST_USERNAME = An (optional) username for the relay server
 $RELAYHOST_PASSWORD = An (optional) login password for the relay server
 $MYNETWORKS = allow domains from per Network ( default 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 )
 $ALLOWED_SENDER_DOMAINS = domains sender domains
+$ALLOW_EMPTY_SENDER_DOMAINS = if value is set (i.e: "true"), $ALLOWED_SENDER_DOMAINS can be unset
 $MASQUERADED_DOMAINS = domains where you want to masquerade internal hosts
 
 ```

--- a/run.sh
+++ b/run.sh
@@ -88,7 +88,7 @@ if [ ! -z "$MESSAGE_SIZE_LIMIT" ]; then
 	echo  -e "‣ $notice Restricting message_size_limit to: ${emphasis}$MESSAGE_SIZE_LIMIT bytes${reset}"
 	postconf -e "message_size_limit=$MESSAGE_SIZE_LIMIT"
 else
-	# As this is a server-based service, allow any message size -- we hope the 
+	# As this is a server-based service, allow any message size -- we hope the
 	# sender knows what he is doing.
 	echo  -e "‣ $info Using ${emphasis}unlimited${reset} message size."
 	postconf -e "message_size_limit=0"
@@ -187,7 +187,7 @@ if [ ! -z "$ALLOWED_SENDER_DOMAINS" ]; then
 
 	# Since we are behind closed doors, let's just permit all relays.
 	postconf -e "smtpd_relay_restrictions=permit"
-else
+elif [ -z "$ALLOW_EMPTY_SENDER_DOMAINS" ]; then
 	echo -e "ERROR: You need to specify ALLOWED_SENDER_DOMAINS otherwise Postfix will not run!"
 	exit 1
 fi


### PR DESCRIPTION
This PR allows setting an empty `ALLOWED_SENDER_DOMAINS` variable. The default behaviour remains the same (empty `ALLOWED_SENDER_DOMAINS` will throw an error), but it is posible to override this behaviour via a new variable `ALLOW_EMPTY_SENDER_DOMAINS`.

The use case is being able to set restrictions on the recipient and not on the sender (anyone can send mails but just to a single domain for instance). This can be achieved by extending the image through custom scripts, and it's cleaner if the base image supports a way not to enforce setting a value on it.