### PR TITLE
Decouple commons.sh from run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,7 @@ COPY       supervisord.conf /etc/supervisord.conf
 COPY       rsyslog.conf /etc/rsyslog.conf
 COPY       opendkim.conf /etc/opendkim/opendkim.conf
 COPY       smtp_header_checks /etc/postfix/smtp_header_checks
-COPY       run.sh /run.sh
-COPY       opendkim.sh /opendkim.sh
+COPY       commons.sh run.sh opendkim.sh /
 RUN        chmod +x /run.sh /opendkim.sh
 
 # Set up volumes

--- a/commons.sh
+++ b/commons.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+reset=""
+yellow=""
+yellow_bold=""
+red=""
+orange=""
+
+# Returns 0 if the specified string contains the specified substring, otherwise returns 1.
+# This exercise it required because we are using the sh-compatible interpretation instead
+# of bash.
+contains() {
+    string="$1"
+    substring="$2"
+    if test "${string#*$substring}" != "$string"
+    then
+        return 0    # $substring is in $string
+    else
+        return 1    # $substring is not in $string
+    fi
+}
+
+if test -t 1; then
+	# Quick and dirty test for color support
+	if contains "$TERM" "256" || contains "$COLORTERM" "256"  || contains "$COLORTERM" "color" || contains "$COLORTERM" "24bit"; then
+		reset="\033[0m"
+		green="\033[38;5;46m"
+		yellow="\033[38;5;178m"
+		red="\033[91m"
+		orange="\033[38;5;208m"
+
+		emphasis="\033[38;5;226m"
+	elif contains "$TERM" "xterm"; then
+		reset="\033[0m"
+		green="\033[32m"
+		yellow="\033[33m"
+		red="\033[31;1m"
+		orange="\033[31m"
+
+		emphasis="\033[33;1m"
+	fi
+fi
+
+info="${green}INFO:${reset}"
+notice="${yellow}NOTE:${reset}"
+warn="${orange}WARN:${reset}"
+error="${red}ERROR:${reset}"

--- a/run.sh
+++ b/run.sh
@@ -1,50 +1,6 @@
 #!/bin/sh
 
-reset=""
-yellow=""
-yellow_bold=""
-red=""
-orange=""
-
-# Returns 0 if the specified string contains the specified substring, otherwise returns 1.
-# This exercise it required because we are using the sh-compatible interpretation instead
-# of bash.
-contains() {
-    string="$1"
-    substring="$2"
-    if test "${string#*$substring}" != "$string"
-    then
-        return 0    # $substring is in $string
-    else
-        return 1    # $substring is not in $string
-    fi
-}
-
-if test -t 1; then
-	# Quick and dirty test for color support
-	if contains "$TERM" "256" || contains "$COLORTERM" "256"  || contains "$COLORTERM" "color" || contains "$COLORTERM" "24bit"; then
-		reset="\033[0m"
-		green="\033[38;5;46m"
-		yellow="\033[38;5;178m"
-		red="\033[91m"
-		orange="\033[38;5;208m"
-
-		emphasis="\033[38;5;226m"
-	elif contains "$TERM" "xterm"; then
-		reset="\033[0m"
-		green="\033[32m"
-		yellow="\033[33m"
-		red="\033[31;1m"
-		orange="\033[31m"
-
-		emphasis="\033[33;1m"
-	fi
-fi
-
-info="${green}INFO:${reset}"
-notice="${yellow}NOTE:${reset}"
-warn="${orange}WARN:${reset}"
-error="${red}ERROR:${reset}"
+. /commons.sh
 
 echo -e "******************************"
 echo -e "**** POSTFIX STARTING UP *****"


### PR DESCRIPTION
This PR splits the `run.sh` bootstrap script into two different scripts: `common.sh` and `run.sh`. `commons.sh` will contain common logic and functions and `run.sh` will contain`postfix`  logic and will source `commons.sh`.

The use case is being able to reuse the common methods when extending the image so that the behaviour is consistent (e.g: same formatting for log messages) without needing to repeat the code while extending.