### PR TITLE
Support alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:latest
+ARG ALPINE_VERSION=latest
+FROM alpine:${ALPINE_VERSION}
 LABEL maintaner="Bojan Cekrlic - https://github.com/bokysan/docker-postfix/"
 
 # See README.md for details

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+if [ $# -eq 0 ]; then
+  echo "No alpine build versions supplied"
+  echo "example usage: ./push.sh latest 3.10 3.9"
+  exit 1
+fi
+
+# Authenticate to push images
+docker login
+
+# build, tag, and push alpine versions supplied as script arguments
+base_repo=boky/postfix
+for alpine_version in "$@"
+do
+  docker build -t "$base_repo":"$alpine_version" --build-arg=ALPINE_VERSION="$alpine_version" .
+  docker push "$base_repo":"$alpine_version"
+done
+
+


### PR DESCRIPTION
Fixes: #19 

Here's a proposal to consider for:
- supporting multiple alpine base image versions
- a script that handles building/tagging/pushing images to docker hub

I tested this out using my own docker hub username, and this seems to work as expected: https://hub.docker.com/repository/docker/mattcritchlow/postfix

This was done running the command: `./push.sh latest 3.10 3.9`

I'm not sure if this completely meets your needs, but hopefully it's a start.