### PR TITLE
Add XOAuth2 support for GMail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 helm/fixtures
 public
 gh-pages
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
 ARG ALPINE_VERSION=latest
+FROM alpine:${ALPINE_VERSION} as build
+
+ARG SASL_XOAUTH2_REPO_URL=https://github.com/tarickb/sasl-xoauth2.git
+ARG SASL_XOAUTH2_GIT_REF=release-0.9
+
+RUN        true && \
+           apk add --no-cache --upgrade git && \
+           apk add --no-cache --upgrade cmake clang make gcc g++ libc-dev pkgconfig curl-dev jsoncpp-dev cyrus-sasl-dev && \
+           git clone --depth 1 --branch ${SASL_XOAUTH2_GIT_REF} ${SASL_XOAUTH2_REPO_URL} /sasl-xoauth2  && \
+           cd /sasl-xoauth2 && \
+           mkdir build && \
+           cd build && \
+           cmake -DCMAKE_INSTALL_PREFIX=/ .. && \
+           make
+
 FROM alpine:${ALPINE_VERSION}
 LABEL maintaner="Bojan Cekrlic - https://github.com/bokysan/docker-postfix/"
 
@@ -10,7 +25,11 @@ RUN        true && \
            apk add --no-cache postfix && \
            apk add --no-cache opendkim && \
            apk add --no-cache --upgrade ca-certificates tzdata supervisor rsyslog musl musl-utils bash opendkim-utils && \
+           apk add --no-cache --upgrade libcurl jsoncpp && \
            (rm "/tmp/"* 2>/dev/null || true) && (rm -rf /var/cache/apk/* 2>/dev/null || true)
+
+# Copy SASL-XOAUTH2 plugin
+COPY       --from=build /sasl-xoauth2/build/src/libsasl-xoauth2.so /usr/lib/sasl2/
 
 # Set up configuration
 COPY       /configs/supervisord.conf     /etc/supervisord.conf

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -13,7 +13,8 @@ run_test() {
         set +e
         docker-compose up --build --abort-on-container-exit --exit-code-from tests
         exit_code="$?"
-        docker-compose down
+
+        docker-compose down -v
         if [[ "$exit_code" != 0 ]]; then
             exit "$exit_code"
         fi

--- a/integration-tests/xoauth2-error/docker-compose.yml
+++ b/integration-tests/xoauth2-error/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.7'
+
+volumes:
+  logs-volume:
+
+services:
+  postfix_test_587:
+    hostname: "postfix"
+    image: "boky/postfix"
+    build:
+      context: ../..
+    restart: always
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "netstat -an | fgrep 587 | fgrep -q LISTEN" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 2
+    environment:
+      FORCE_COLOR: "1"
+      ALLOW_EMPTY_SENDER_DOMAINS: "true"
+      RELAYHOST: "[smtp.gmail.com]:587"
+      RELAYHOST_USERNAME: "${RELAYHOST_USERNAME}"
+      RELAYHOST_TLS_LEVEL: "encrypt"
+      XOAUTH2_CLIENT_ID: "${XOAUTH2_CLIENT_ID}"
+      XOAUTH2_SECRET: "${XOAUTH2_SECRET}"
+      XOAUTH2_INITIAL_ACCESS_TOKEN: "${XOAUTH2_INITIAL_ACCESS_TOKEN}"
+      XOAUTH2_INITIAL_REFRESH_TOKEN: "${XOAUTH2_INITIAL_REFRESH_TOKEN}"
+      XOAUTH2_SYSLOG_ON_FAILURE: "no"
+      XOAUTH2_FULL_TRACE: "no"
+      LOG_FORMAT: "json"
+      POSTFIX_maillog_file: "/logs/postfix.log"
+      POSTFIX_maillog_file_prefixes: "/var,/dev/sdout,/logs"
+    volumes:
+      - "logs-volume:/logs"
+  tests:
+    image: "boky/postfix-integration-test"
+    restart: "no"
+    volumes:
+      - "../xoauth2/common:/common"
+      - "./it:/code"
+      - "logs-volume:/logs"
+    build:
+      context: ../tester
+    command: "/"
+    environment:
+      FROM: "${FROM}"
+      TO: "${TO}"
+      SKIP_INVALID_DOMAIN_SEND: "1"

--- a/integration-tests/xoauth2-error/it/test.bats
+++ b/integration-tests/xoauth2-error/it/test.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+if [ -z "$FROM" ]; then
+  FROM=$1
+  shift
+fi
+
+if [ -z "$TO" ]; then
+  TO=$1
+  shift
+fi
+
+# Wait for postfix to startup
+wait-for-service -q tcp://postfix_test_587:587
+
+SMTP_DATA="-smtp postfix_test_587 -port 587"
+
+load /common/common-xoauth2.sh
+
+@test "Relay email with proper XOAuth2 credentials" {
+	local message_id="12345.test@example.com"
+	local postfix_message_id=''
+	local smtp_result=''
+	local status=''
+
+	mailsend \
+		-sub "Test email 1" $SMTP_DATA \
+		-from $FROM \
+		-to $TO \
+		header \
+			-name "Message-ID" \
+			-value "${message_id}" \
+		body \
+			-msg "Hello world!\nThis is a simple test message!"
+
+	postfix_message_id=$(get_postfix_message_id '/logs/postfix.log' ${message_id})
+	smtp_result=$(get_smtp_result '/logs/postfix.log' "${postfix_message_id}")
+	status=$(get_param_value "${smtp_result}" 'status')
+
+	[ -n "$status" ]
+	echo "$status" | grep -q -E "^deferred"
+}

--- a/integration-tests/xoauth2/common/common-xoauth2.sh
+++ b/integration-tests/xoauth2/common/common-xoauth2.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+get_postfix_message_id() {
+	local log_file=$1
+	local message_id=$2
+	local postfix_message_id=''
+	local result='ko'
+	local count=0;
+	local max_wait=15
+	while [[ $result == 'ko' ]] && [[ $count -lt $max_wait ]]; do
+		postfix_message_id=$(cat ${log_file} | grep -E -e 'postfix/cleanup' | cut -d':' -f4- | sed -r -e "s/\s*([^:]+)\s*:\s*message-id=${message_id}/\1/")
+		if [[ -n "$postfix_message_id" ]]; then
+			result='ok'
+		else
+			sleep 1
+			count=$((count+1))
+		fi
+	done
+
+	if [[ $count -eq $max_wait ]]; then
+		echo >&2 "Message with message-id='${message_id}' not found"
+		return 1
+	fi
+
+    echo ${postfix_message_id}
+    return 0
+}
+
+get_smtp_result() {
+	local log_file=$1
+	local postfix_message_id=$2
+	local smtp_result=''
+	local result='ko'
+	local count=0
+	local max_wait=15
+
+	while [[ $result == 'ko' ]] && [[ $count -lt $max_wait ]]; do
+		smtp_result=$(cat ${log_file} | grep -E -e 'postfix/smtp\[' | cut -d':' -f4- | sed -r -e "s/${postfix_message_id}:(.*)/\1/g")
+		if [[ -n "$smtp_result" ]]; then
+			result='ok'
+		else
+			sleep 1
+			count=$((count+1))
+        fi
+	done
+
+	if [[ $count -eq $max_wait ]]; then
+		echo >&2 "Message with postfix id='${postfix_message_id}' not found"
+		return 1
+	fi
+
+    echo ${smtp_result}
+    return 0
+}
+
+get_param_value() {
+	local smtp_result=$1
+	local param_name_to_search=$2
+	local params=''
+	local param_name=''
+	local param_value=''
+	local status=''
+
+	local old_ifs=$IFS
+	IFS=','
+	read -ra params <<< "${smtp_result}"
+	IFS=$old_ifs
+
+	for i in "${params[@]}"; do
+		param_name=$(echo $i | cut -d'=' -f1)
+		param_value=$(echo $i | cut -d'=' -f2)
+		if [[ "${param_name}" == "${param_name_to_search}" ]]; then
+			status="${param_value}"
+			break;
+		fi
+		echo $i;
+	done
+
+	if [[ -z "${status}" ]]; then
+		echo "${param_name_to_search} not found!."
+		return 1
+	fi
+
+	echo "${status}"
+	return 0
+}

--- a/integration-tests/xoauth2/docker-compose.yml
+++ b/integration-tests/xoauth2/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.7'
+
+volumes:
+  logs-volume:
+services:
+  postfix_test_587:
+    hostname: "postfix"
+    image: "boky/postfix"
+    build:
+      context: ../..
+    restart: always
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "netstat -an | fgrep 587 | fgrep -q LISTEN" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 2
+    environment:
+      FORCE_COLOR: "1"
+      ALLOW_EMPTY_SENDER_DOMAINS: "true"
+      RELAYHOST: "[smtp.gmail.com]:587"
+      RELAYHOST_USERNAME: "${RELAYHOST_USERNAME}"
+      RELAYHOST_TLS_LEVEL: "encrypt"
+      XOAUTH2_CLIENT_ID: "${XOAUTH2_CLIENT_ID}"
+      XOAUTH2_SECRET: "${XOAUTH2_SECRET}"
+      XOAUTH2_INITIAL_ACCESS_TOKEN: "${XOAUTH2_INITIAL_ACCESS_TOKEN}"
+      XOAUTH2_INITIAL_REFRESH_TOKEN: "${XOAUTH2_INITIAL_REFRESH_TOKEN}"
+      XOAUTH2_SYSLOG_ON_FAILURE: "no"
+      XOAUTH2_FULL_TRACE: "no"
+      LOG_FORMAT: "json"
+      POSTFIX_maillog_file: "/logs/postfix.log"
+      POSTFIX_maillog_file_prefixes: "/var,/dev/sdout,/logs"
+    volumes:
+      - "logs-volume:/logs"
+  tests:
+    image: "boky/postfix-integration-test"
+    restart: "no"
+    volumes:
+      - "./common:/common"
+      - "./it:/code"
+      - "logs-volume:/logs"
+    build:
+      context: ../tester
+    command: "/"
+    environment:
+      FROM: "${FROM}"
+      TO: "${TO}"
+      SKIP_INVALID_DOMAIN_SEND: "1"

--- a/integration-tests/xoauth2/it/test.bats
+++ b/integration-tests/xoauth2/it/test.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+if [ -z "$FROM" ]; then
+  FROM=$1
+  shift
+fi
+
+if [ -z "$TO" ]; then
+  TO=$1
+  shift
+fi
+
+# Wait for postfix to startup
+wait-for-service -q tcp://postfix_test_587:587
+
+SMTP_DATA="-smtp postfix_test_587 -port 587"
+
+load /common/common-xoauth2.sh
+
+@test "Relay email with proper credentials" {
+	local message_id="12345.test@example.com"
+	local postfix_message_id=''
+	local smtp_result=''
+	local status=''
+
+	mailsend \
+		-sub "Test email 1" $SMTP_DATA \
+		-from $FROM \
+		-to $TO \
+		header \
+			-name "Message-ID" \
+			-value "${message_id}" \
+		body \
+			-msg "Hello world!\nThis is a simple test message!"
+
+	postfix_message_id=$(get_postfix_message_id '/logs/postfix.log' ${message_id})
+	smtp_result=$(get_smtp_result '/logs/postfix.log' "${postfix_message_id}")
+	status=$(get_param_value "${smtp_result}" 'status')
+
+	[ -n "$status" ]
+	echo "$status" | grep -q -E "^sent"
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -172,4 +172,26 @@ do_postconf() {
 
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+#
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 export reset green yellow orange orange_emphasis lightblue red gray emphasis underline

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,7 +17,9 @@ postfix_restrict_message_size       # Restrict the size of messages (or set them
 postfix_reject_invalid_helos        # Reject invalid HELOs
 postfix_set_hostname                # Set up host name
 postfix_set_relay_tls_level         # Set TLS level security for relays
+postfix_setup_xoauth2_pre_setup     # (Pre) Setup XOAUTH2 authentication
 postfix_setup_relayhost             # Setup a relay host, if defined
+postfix_setup_xoauth2_post_setup    # (Post) Setup XOAUTH2 autentication
 postfix_setup_networks              # Set MYNETWORKS
 postfix_setup_debugging             # Enable debugging, if defined
 postfix_setup_sender_domains        # Configure allowed sender domains
@@ -28,6 +30,7 @@ postfix_custom_commands             # Apply custom postfix settings
 opendkim_custom_commands            # Apply custom OpenDKIM settings
 postfix_open_submission_port        # Enable the submission port
 execute_post_init_scripts           # Execute any scripts found in /docker-init.db/
+unset_sensible_variables            # Remove environment variables that contains sensible values (secrets) that are read from conf files
 
 notice "Starting: ${emphasis}rsyslog${reset}, ${emphasis}postfix${reset}$DKIM_ENABLED"
 exec supervisord -c /etc/supervisord.conf

--- a/unit-tests/Dockerfile
+++ b/unit-tests/Dockerfile
@@ -1,4 +1,19 @@
 ARG ALPINE_VERSION=latest
+FROM alpine:${ALPINE_VERSION} as build
+
+ARG SASL_XOAUTH2_REPO_URL=https://github.com/tarickb/sasl-xoauth2.git
+ARG SASL_XOAUTH2_GIT_REF=release-0.9
+
+RUN        true && \
+           apk add --no-cache --upgrade git && \
+           apk add --no-cache --upgrade cmake clang make gcc g++ libc-dev pkgconfig curl-dev jsoncpp-dev cyrus-sasl-dev && \
+           git clone --depth 1 --branch ${SASL_XOAUTH2_GIT_REF} ${SASL_XOAUTH2_REPO_URL} /sasl-xoauth2  && \
+           cd /sasl-xoauth2 && \
+           mkdir build && \
+           cd build && \
+           cmake -DCMAKE_INSTALL_PREFIX=/ .. && \
+           make
+
 FROM alpine:${ALPINE_VERSION}
 LABEL maintaner="Bojan Cekrlic - https://github.com/bokysan/docker-postfix/"
 
@@ -7,9 +22,13 @@ RUN        true && \
            apk add --no-cache postfix && \
            apk add --no-cache opendkim && \
            apk add --no-cache --upgrade ca-certificates tzdata supervisor rsyslog musl musl-utils bash opendkim-utils && \
+           apk add --no-cache --upgrade libcurl jsoncpp && \
            (rm "/tmp/"* 2>/dev/null || true) && (rm -rf /var/cache/apk/* 2>/dev/null || true)
 RUN        apk add --no-cache bash bats && \
            (rm "/tmp/"* 2>/dev/null || true) && (rm -rf /var/cache/apk/* 2>/dev/null || true)
+
+# Copy SASL-XOAUTH2 plugin
+COPY       --from=build /sasl-xoauth2/build/src/libsasl-xoauth2.so /usr/lib/sasl2/
 
 WORKDIR    /code
 ENTRYPOINT ["/usr/bin/bats"]

--- a/unit-tests/xoauth2_support.bats
+++ b/unit-tests/xoauth2_support.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+load /code/scripts/common.sh
+load /code/scripts/common-run.sh
+
+@test "check sentive variables are unset" {
+	local RELAYHOST_PASSWORD="password"
+	local XOAUTH2_CLIENT_ID="client_id"
+	local XOAUTH2_SECRET="secret"
+	local XOAUTH2_INITIAL_ACCESS_TOKEN="access_token"
+	local XOAUTH2_INITIAL_REFRESH_TOKEN="refres_token"
+
+	unset_sensible_variables
+
+	[ -z "$RELAYHOST_PASSWORD" ]
+	[ -z "$XOAUTH2_CLIENT_ID" ]
+	[ -z "$XOAUTH2_SECRET" ]
+	[ -z "$XOAUTH2_INITIAL_ACCESS_TOKEN" ]
+	[ -z "$XOAUTH2_INITIAL_REFRESH_TOKEN" ]
+}
+
+@test "reading sensitive values from environment or from file" {
+	local RELAYHOST_PASSWORD="password"
+
+	local tmp_file=$(mktemp)
+	echo "password" > $tmp_file
+	local XOAUTH2_CLIENT_ID_FILE="$tmp_file"
+
+	file_env 'RELAYHOST_PASSWORD'
+	file_env 'XOAUTH2_CLIENT_ID'
+
+	[ -n "$RELAYHOST_PASSWORD" ]
+	[ -n "$XOAUTH2_CLIENT_ID" ]
+}
+
+@test "pre-configure xoauth2 in postfix only if relayhost is configured" {
+	local RELAYHOST="[smtp.example.org]:597"
+	local RELAYHOST_USERNAME="your.acount@example.org"
+	local XOAUTH2_CLIENT_ID="client_id"
+	local XOAUTH2_SECRET="secret"
+	local XOAUTH2_SYSLOG_ON_FAILURE="no"
+	local XOAUTH2_FULL_TRACE="yes"
+	local XOAUTH2_INITIAL_ACCESS_TOKEN="access_token"
+	local XOAUTH2_INITIAL_REFRESH_TOKEN="refresh_token"
+
+	postfix_setup_xoauth2_pre_setup
+
+	[ -f "/etc/sasl-xoauth2.conf" ]
+	result=$(cat /etc/sasl-xoauth2.conf | grep -e 'client_id' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_CLIENT_ID" ]
+	result=$(cat /etc/sasl-xoauth2.conf | grep -e 'client_secret' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_SECRET" ]
+	result=$(cat /etc/sasl-xoauth2.conf | grep -e 'log_to_syslog_on_failure' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_SYSLOG_ON_FAILURE" ]
+	result=$(cat /etc/sasl-xoauth2.conf | grep -e 'log_full_trace_on_failure' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_FULL_TRACE" ]
+	[ "$RELAYHOST_PASSWORD" == "/var/spool/postfix/xoauth2-tokens/${RELAYHOST_USERNAME}" ]
+	result=$(cat "${RELAYHOST_PASSWORD}" | grep -e 'access_token' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_INITIAL_ACCESS_TOKEN" ]
+	result=$(cat "${RELAYHOST_PASSWORD}" | grep -e 'refresh_token' | sed -r 's/\s*"[^"]+"\s*:\s*"([^,]*)"\s*,?/\1/')
+	[ "$result" == "$XOAUTH2_INITIAL_REFRESH_TOKEN" ]
+}
+
+@test "pre-configure error trying to configure xoauth2 in postfix if relayhost is not configured" {
+	local XOAUTH2_CLIENT_ID="client_id"
+	local XOAUTH2_SECRET="secret"
+
+	local RELAYHOST="[smtp.example.org]:597"
+
+	run postfix_setup_xoauth2_pre_setup
+
+	[ "$status" -eq 1 ]
+	[ "$output" == "‣ ERROR You need to specify RELAYHOST and RELAYHOST_USERNAME otherwise Postfix will not run!" ]
+
+	unset RELAYHOST
+	local RELAYHOST_USERNAME="your.acount@example.org"
+
+	run postfix_setup_xoauth2_pre_setup
+
+	[ "$status" -eq 1 ]
+	[ "$output" == "‣ ERROR You need to specify RELAYHOST and RELAYHOST_USERNAME otherwise Postfix will not run!" ]
+}
+
+@test "post-configure xoauth2 not needed" {
+	local XOAUTH2_CLIENT_ID="client_id"
+
+	postfix_setup_xoauth2_post_setup
+
+	postfix check
+
+	result=$(cat /etc/postfix/main.cf | grep -e 'smtp_sasl_mechanism_filter' | sed -r 's/\s*[^\s]+\s*=\s*([^\s]*)/\1/')
+	[ "$result" != "xoauth2" ]
+}
+
+@test "post-configure xoauth2 required" {
+	local XOAUTH2_CLIENT_ID="client_id"
+	local XOAUTH2_SECRET="secret"
+
+	postfix_setup_xoauth2_post_setup
+
+	postfix check
+
+	cat /etc/postfix/main.cf | grep -q -E '^\s*smtp_sasl_security_options\s*=\s*$'
+	local status=$?
+	[ "$status" -eq 0 ]
+
+	cat /etc/postfix/main.cf | grep -q -E '^\s*smtp_sasl_mechanism_filter\s*=\s*xoauth2$'
+	local status=$?
+	[ "$status" -eq 0 ]
+
+	cat /etc/postfix/main.cf | grep -q -E '^\s*smtp_tls_session_cache_database\s*=\s*btree:\$\{data_directory\}/smtp_scache$'
+	local status=$?
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
  This PR, uses https://github.com/tarickb/sasl-xoauth2 to add support for the XOAuth2 authentication method that is usually required / recommend for some providers like GMail. Currently this library it is specifically designed for GMail, but seems that there is a discussion to provide support for [other providers like Office365](https://github.com/tarickb/sasl-xoauth2/issues/4) ([there is an active PR](https://github.com/tarickb/sasl-xoauth2/pull/5)).

  More precisely, this PR does:
- Changes the Dockerfile to add a multi-stage build to build the SASL XOAuth2 library and then copy the result to the actual image. This build stage is configurable using docker build args.
- Define and document `RELAYHOST_TLS_LEVEL`, `XOAUTH2_CLIENT_ID`, `XOAUTH2_SECRET`, `XOAUTH2_INITIAL_ACCESS_TOKEN`, `XOAUTH2_INITIAL_REFRESH_TOKEN` environment variables to configure the XOAuth2 authentication.
- Modify entrypoint scripts to enable this feature if it is configured `RELAYHOST` and `RELAYHOST_USERNAME` too.
- Add a support function (file_env) to allow to pass sensitive values using a file instead of through environment variables. In addition to adhere to good practices, this allows to use Docker secrets or k8s secrets.
- Add extra step in the main entrypoint script to remove from the env variables that contains sensitive values.

Related to #41