### PR TITLE
Add option to use a specific nodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Chart configuration is as follows:
 | `service.port` | `587` | SMTP submission port |
 | `service.labels` | `{}` | Additional service labels |
 | `service.annotations` | `{}` | Additional service annotations |
+| `service.nodePort` | *empty* | Use a specific `nodePort` |
 | `resources` | `{}` | [Pod resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | `autoscaling.enabled` | `false` | Set to `true` to enable [Horisontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | `autoscaling.minReplicas` | `1` | Minimum number of replicas |

--- a/helm/mail/templates/service.yaml
+++ b/helm/mail/templates/service.yaml
@@ -18,5 +18,6 @@ spec:
       targetPort: smtp
       protocol: TCP
       name: smtp
+      {{ if eq .Values.service.type "NodePort" }}nodePort: {{ .Values.service.nodePort }}{{ end }}
   selector:
     {{- $selectorLabels | nindent 4 }}

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -19,6 +19,7 @@ service:
   port: 587
   labels: {}
   annotations: {}
+  # nodePort:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR allows to specify a value for `nodePort` if `service.type` is `NodePort`. If the value is not set it will allocate a random port (so won't change the previous behaviour).