### PR TITLE
add SASL_RELAYHOST to overwrite RELATHOST in sasl_passwd file on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ To change the log format, set the (unsurprisingly named) variable `LOG_FORMAT=js
 ### Postfix-specific options
 
 * `RELAYHOST` = Host that relays your messages
+* `SASL_RELAYHOST` = (optional) Relay Host referenced in the `sasl_passwd` file. Defaults to the value of `RELAYHOST`
 * `RELAYHOST_USERNAME` = An (optional) username for the relay server
 * `RELAYHOST_PASSWORD` = An (optional) login password for the relay server
 * `RELAYHOST_PASSWORD_FILE` = An (optional) file containing the login password for the relay server. Mutually exclusive with the previous option.

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -89,6 +89,7 @@ config:
     # ALLOW_EMPTY_SENDER_DOMAINS:
     # LOG_FORMAT:
     # RELAYHOST:
+    # SASL_RELAYHOST: # when specified overwrites the RELAYHOST in the sasl_passwd file
     # RELAYHOST_USERNAME:
     # RELAYHOST_PASSWORD:
     # MASQUERADED_DOMAINS:

--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -168,15 +168,20 @@ postfix_setup_relayhost() {
 
 		file_env 'RELAYHOST_PASSWORD'
 
+		# Allow to overwrite RELAYHOST in the sasl_passwd file with SASL_RELAYHOST variable if specified
+		if [ -z "$SASL_RELAYHOST" ]; then
+			SASL_RELAYHOST=$RELAYHOST
+		fi
+
 		if [ -n "$RELAYHOST_USERNAME" ] && [ -n "$RELAYHOST_PASSWORD" ]; then
 			echo -e " using username ${emphasis}$RELAYHOST_USERNAME${reset} and password ${emphasis}(redacted)${reset}."
 			if [[ -f /etc/postfix/sasl_passwd ]]; then
-				if ! grep -F "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" /etc/postfix/sasl_passwd; then
-					sed -i -e "s/^$RELAYHOST .*$/d" /etc/postfix/sasl_passwd
-					echo "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" >> /etc/postfix/sasl_passwd
+				if ! grep -F "$SASL_RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" /etc/postfix/sasl_passwd; then
+					sed -i -e "s/^$SASL_RELAYHOST .*$/d" /etc/postfix/sasl_passwd
+					echo "$SASL_RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" >> /etc/postfix/sasl_passwd
 				fi
 			else
-				echo "$RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" >> /etc/postfix/sasl_passwd
+				echo "$SASL_RELAYHOST $RELAYHOST_USERNAME:$RELAYHOST_PASSWORD" >> /etc/postfix/sasl_passwd
 			fi
 			postmap lmdb:/etc/postfix/sasl_passwd
 			chown root:root /etc/postfix/sasl_passwd /etc/postfix/sasl_passwd.lmdb


### PR DESCRIPTION
This PR adds a `SASL_RELAYHOST` variable that overwrites the `RELAYHOST` inside the `sasl_passwd` file when specified (see #76).
By default, the `RELAYHOST` value will be used, as is currently the case.

Let me know if you have any questions or concerns.
Thanks a lot!