### PR TITLE
Add feature to bring your own secret resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Chart configuration is as follows:
 | `config.postfix` | `{}` | Key-value list of general postfix options, e.g. `myhostname: "demo"` |
 | `config.opendkim` | `{}` | Key-value list of general OpenDKIM options, e.g. `RequireSafeKeys: "yes"` |
 | `secret` | `{}` | Key-value list of environment variables to be shared with Postfix / OpenDKIM as secrets |
+| `existingSecret` | `""` | A reference to an existing opaque secret. Secret is mounted and exposed as environment variables in the pod |
 | `mountSecret.enabled` | `false` | Create a folder with contents of the secret in the pod's container |
 | `mountSecret.path` | `/var/lib/secret` | Where to mount secret data |
 | `mountSecret.data` | `{}` | Key-value list of files to be mount into the container |

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -88,6 +88,10 @@ spec:
             - secretRef:
                 name: {{ $fullName | quote }}
             {{- end }}
+            {{- if .Values.existingSecret }}
+            - secretRef:
+                name: {{ .Values.existingSecret | quote }}
+            {{- end }}
           {{ with .Values.extraEnv }}env: {{- toYaml . | nindent 12 }}{{ end }}
           volumeMounts:
             - mountPath: /var/spool/postfix

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -90,6 +90,10 @@ certs:
 #   hello: world
 secret: {}
 
+# Use an existing secret to share with the pod
+# as environment variables.
+existingSecret: ""
+
 # Define a secret which should be deployed together with the
 # chart amd mounted into a specific directory in the pod.
 mountSecret:

--- a/helm/test_11_existing_secret.yml
+++ b/helm/test_11_existing_secret.yml
@@ -1,0 +1,1 @@
+existingSecret: controller-generated-secret


### PR DESCRIPTION
Hi this PR seeks to implement functionality to load existing secrets as environment variables in the pod.

The rationale behind this PR:
We use a controller that retrieves secrets from an external system and creates them in kubernetes. This PR would allow us to deploy this helmchart which simply consumes the existing secret provisioned by the controller. 