### PR TITLE
Support for metrics

### DIFF
--- a/helm/mail/templates/configmap-logrotate.yaml
+++ b/helm/mail/templates/configmap-logrotate.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.logrotate.enabled }}
+{{- $chart := "mail" -}}
+{{- $labels := include (print $chart ".labels") . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logrotate-config
+  labels:
+    {{- $labels | nindent 4 }}
+data:
+  logrotate.conf: |
+    /var/log/mail.log {
+        rotate 1
+        monthly
+        minsize 1M
+        compress
+        missingok
+        notifempty
+        dateext
+        olddir /var/log/old
+        maxage 90
+    }
+{{- end }}
+{{- end }}

--- a/helm/mail/templates/configmap.yaml
+++ b/helm/mail/templates/configmap.yaml
@@ -13,6 +13,9 @@ data:
   {{- range $key, $value := .Values.config.postfix }}
   POSTFIX_{{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{- if .Values.metrics.enabled }}
+  POSTFIX_maillog_file: {{ .Values.metrics.maillog }}
+  {{- end }}
   {{- range $key, $value := .Values.config.opendkim }}
   OPENDKIM_{{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/helm/mail/templates/service-metrics.yaml
+++ b/helm/mail/templates/service-metrics.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.metrics.enabled -}}
+{{- $chart := "mail" -}}
+{{- $fullName := include (print $chart ".fullname") . -}}
+{{- $labels := include (print $chart ".labels") . -}}
+{{- $selectorLabels := include (print $chart ".selectorLabels") . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName | quote }}-metrics
+  labels:
+    {{- $labels | nindent 4 }}
+    {{- with .Values.service.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+  annotations:
+    {{- with .Values.service.annotations }}{{ toYaml . | nindent 4 }}{{ end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.spec }}{{ toYaml . | nindent 2 }}{{ end }}
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- $selectorLabels | nindent 4 }}
+{{- end -}}

--- a/helm/mail/templates/service-metrics.yaml
+++ b/helm/mail/templates/service-metrics.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullName | quote }}-metrics
+  name: mail-metrics
   labels:
     {{- $labels | nindent 4 }}
     {{- with .Values.service.labels }}{{ toYaml . | nindent 4 }}{{ end }}

--- a/helm/mail/templates/service-monitor.yaml
+++ b/helm/mail/templates/service-monitor.yaml
@@ -3,24 +3,24 @@
 {{- $fullName := include (print $chart ".fullname") . -}}
 {{- $labels := include (print $chart ".labels") . -}}
 {{- $selectorLabels := include (print $chart ".selectorLabels") . -}}
-apiVersion: v1
-kind: Service
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
   name: mail-metrics
   labels:
     {{- $labels | nindent 4 }}
     {{- with .Values.service.labels }}{{ toYaml . | nindent 4 }}{{ end }}
-    prometheus: unknown
   annotations:
     {{- with .Values.service.annotations }}{{ toYaml . | nindent 4 }}{{ end }}
 spec:
-  type: ClusterIP
-  {{- with .Values.service.spec }}{{ toYaml . | nindent 2 }}{{ end }}
-  ports:
-    - port: {{ .Values.metrics.port }}
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
+  endpoints:
+  - interval: 15s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
   selector:
-    {{- $selectorLabels | nindent 4 }}
+    matchLabels:
+      app.kubernetes.io/instance: {{ $chart }}
+      prometheus: unknown
 {{- end -}}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -96,10 +96,6 @@ spec:
           volumeMounts:
             - mountPath: /var/spool/postfix
               name: {{ $fullName }}
-            - mountPath: /var/spool/postfix/private
-              name: private
-            - mountPath: /var/spool/postfix/public
-              name: public
             {{- if .Values.certs.create }}
             - name: certs
               mountPath: /var/run/certs
@@ -120,12 +116,7 @@ spec:
         {{- tpl .Values.extraContainers $root | nindent 8 }}
         {{- end }}
       volumes:
-        # Socket directories
-        - name: public
-          emptyDir: {}
-        - name: private
-          emptyDir: {}
-        {{- if .Values.certs.create }}
+            {{- if .Values.certs.create }}
         - name: certs-init
           configMap:
             name: {{ $fullName }}
@@ -134,6 +125,7 @@ spec:
           secret:
             secretName: {{ $fullName }}-certs
         {{- end }}
+        # Socket directories
         {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: {{ $fullName }}
           persistentVolumeClaim:

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -73,12 +73,6 @@ spec:
           lifecycle:
             # If a container has a preStop hook configured, that runs before the container enters the Terminated state.
             {{- if .Values.metrics.enabled }}
-            preStop:
-              exec:
-                command:
-                  - bash
-                  - -c
-                  - touch /tmp/container_is_terminating && echo "Flushing pending queue..." && postqueue -f; sleep 10s;  killall5 -15 supervisord
             {{- else }}
             preStop:
               exec:

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -72,15 +72,12 @@ spec:
           startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
           lifecycle:
             # If a container has a preStop hook configured, that runs before the container enters the Terminated state.
-            {{- if .Values.metrics.enabled }}
-            {{- else }}
             preStop:
               exec:
                 command:
                   - bash
                   - -c
                   - touch /tmp/container_is_terminating && while ! [[ "`mailq`" == *empty* ]]; do echo "Flushing queue..." && postfix flush; sleep 1; done; killall5 -15 supervisord
-            {{- end }}
             {{- if .Values.lifecycle.postStart }}
             postStart: {{- toYaml .Values.lifecycle.postStart | nindent 14 }}
             {{- end }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -72,12 +72,21 @@ spec:
           startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
           lifecycle:
             # If a container has a preStop hook configured, that runs before the container enters the Terminated state.
+            {{- if .Values.metrics.enabled }}
+            preStop:
+              exec:
+                command:
+                  - bash
+                  - -c
+                  - touch /tmp/container_is_terminating && echo "Flushing pending queue..." && postqueue -f; sleep 10s;  killall5 -15 supervisord
+            {{- else }}
             preStop:
               exec:
                 command:
                   - bash
                   - -c
                   - touch /tmp/container_is_terminating && while ! [[ "`mailq`" == *empty* ]]; do echo "Flushing queue..." && postfix flush; sleep 1; done; killall5 -15 supervisord
+            {{- end }}
             {{- if .Values.lifecycle.postStart }}
             postStart: {{- toYaml .Values.lifecycle.postStart | nindent 14 }}
             {{- end }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
             - mountPath: /var/spool/postfix
               name: {{ $fullName }}
               subPath: spool
-              {{ - if .Values.metrics.enabled }}
+              {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}
               mountPath: /var/log/
               readOnly: false

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -119,6 +119,44 @@ spec:
             {{- end }}
             {{- if .Values.extraVolumeMounts }}{{- toYaml .Values.extraVolumeMounts | nindent 12 }}{{ end }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.metrics.enabled }}
+        - name: exporter
+          imagePullPolicy: Always
+          image: {{ .Values.metrics.image }}
+          ports:
+          - containerPort: {{ .Values.metrics.port }}
+            name: metrics
+            protocol: TCP
+          args:
+          - sleep 15s; /bin/postfix_exporter
+          command:
+          - sh
+          - -c
+          volumeMounts:
+            - mountPath: /var/spool/postfix
+              name: {{ $fullName }}
+              subPath: spool
+            - mountPath: /var/log/
+              name: {{ $fullName }}
+              subPath: logs
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.metrics.port }}
+            initialDelaySeconds: 5
+        - name: postfix-logs
+          imagePullPolicy: Always
+          image: alpine:latest
+          args:
+          - sleep 15s; tail {{ .Values.metrics.maillog }} -f | grep -v "connect from localhost\[127\.0\.0\.1\]\|lost connection after EHLO from localhost\[127\.0\.0\.1\]"
+          command:
+          - sh
+          - -c
+          volumeMounts:
+            - mountPath: /var/log/
+              name: {{ $fullName }}
+              subPath: logs
+        {{- end }}
         {{- if .Values.extraContainers }}
         {{- tpl .Values.extraContainers $root | nindent 8 }}
         {{- end }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -156,6 +156,15 @@ spec:
             - mountPath: /var/log/
               name: {{ $fullName }}
               subPath: logs
+        {{- if .Values.metrics.logrotate.enabled }}
+        - name: logrotate
+          image: blacklabelops/logrotate
+          volumeMounts:
+          - mountPath: /var/log
+            name: {{ $fullName }}
+          - mountPath: /etc/logrotate.d
+            name: logrotate-config
+        {{- end }}
         {{- end }}
         {{- if .Values.extraContainers }}
         {{- tpl .Values.extraContainers $root | nindent 8 }}
@@ -185,6 +194,14 @@ spec:
         - name: mount-secret
           secret:
             secretName: {{ $fullName }}-mount
+        {{- end }}
+
+        {{- if .Values.metrics.enabled }}
+        {{- if .Values.metrics.logrotate.enabled }}
+        - name: logrotate-config
+          configMap:
+            name: logrotate-config
+        {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}{{- toYaml .Values.extraVolumes | nindent 8 }}{{ end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -96,6 +96,13 @@ spec:
           volumeMounts:
             - mountPath: /var/spool/postfix
               name: {{ $fullName }}
+              subPath: spool
+              {{ - if .Values.metrics.enabled }}
+            - name: {{ $fullName }}
+              mountPath: /var/log/
+              readOnly: false
+              subPath: logs
+              {{- end }}
             {{- if .Values.certs.create }}
             - name: certs
               mountPath: /var/run/certs

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -91,6 +91,10 @@ extraContainers: []
 #     volumeMounts:
 #       - mountPath: /var/spool/postfix
 #         name: mail
+#       - mountPath: /var/spool/postfix/private
+#         name: private
+#       - mountPath: /var/spool/postfix/public
+#         name: public
 #       - mountPath: /var/log/
 #         name: logs
 #     readinessProbe:

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -21,7 +21,7 @@ service:
   annotations: {}
   # nodePort:
 
-metrics: 
+metrics:
   enabled: false
   port: 9154
 

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -64,6 +64,51 @@ extraVolumeMounts: []
 extraInitContainers: []
 extraEnv: []
 extraContainers: []
+#Enable to following blocks for metrics
+
+# extraVolumeMounts: 
+# - name: logs
+#   mountPath: /var/log/
+#   readOnly: false
+
+# extraVolumes:
+#   - name: logs
+#     emptyDir: {}
+
+# extraContainers: |
+#   - name: exporter
+#     imagePullPolicy: Always
+#     image: <REPO>/postfix_exporter:v1.0.0
+#     ports:
+#     - containerPort: 9154
+#       name: metrics
+#       protocol: TCP
+#     args:
+#     - sleep 15s; /bin/postfix_exporter
+#     command:
+#     - sh
+#     - -c
+#     volumeMounts:
+#       - mountPath: /var/spool/postfix
+#         name: mail
+#       - mountPath: /var/log/
+#         name: logs
+#     readinessProbe:
+#       httpGet:
+#         path: /metrics
+#         port: 9154
+#       initialDelaySeconds: 5
+#   - name: postfix-logs
+#     imagePullPolicy: Always
+#     image: alpine:latest
+#     args:
+#     - sleep 15s; tail /var/log/mail.log -f | grep -v "connect from localhost\[127\.0\.0\.1\]\|lost connection after EHLO from localhost\[127\.0\.0\.1\]"
+#     command:
+#     - sh
+#     - -c
+#     volumeMounts:
+#       - mountPath: /var/log/
+#         name: logs
 
 deployment:
   labels: {}
@@ -130,6 +175,7 @@ config:
   postfix: {}
     # e.g.
     # myhostname: "postfix"
+    # maillog_file: /var/log/mail.log # Enable this for metrics
     # smtp_tls_security_level: "encrypt"
   opendkim: {}
     # e.g.

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -21,6 +21,10 @@ service:
   annotations: {}
   # nodePort:
 
+metrics: 
+  enabled: false
+  port: 9154
+
 # Tell helm to restart (recreate) pods on every deploy. Setting this to true will inject
 # `date/deploy-date: <timestamp>` annotation into pod specification for StateFulset. This
 # ensures that the Pod is recreated with the new changes.

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -24,6 +24,9 @@ service:
 metrics:
   enabled: false
   port: 9154
+  image: ""
+  #This is what https://github.com/kumina/postfix_exporter is expecting, so setting as default
+  maillog: /var/log/mail.log
 
 # Tell helm to restart (recreate) pods on every deploy. Setting this to true will inject
 # `date/deploy-date: <timestamp>` annotation into pod specification for StateFulset. This
@@ -64,44 +67,6 @@ extraVolumeMounts: []
 extraInitContainers: []
 extraEnv: []
 extraContainers: []
-#Enable to following blocks for metrics
-# extraContainers: |
-#   - name: exporter
-#     imagePullPolicy: Always
-#     image: <REPO>/postfix_exporter:v1.0.0
-#     ports:
-#     - containerPort: 9154
-#       name: metrics
-#       protocol: TCP
-#     args:
-#     - sleep 15s; /bin/postfix_exporter
-#     command:
-#     - sh
-#     - -c
-#     volumeMounts:
-#       - mountPath: /var/spool/postfix
-#         name: mail
-#         subPath: spool
-#       - mountPath: /var/log/
-#         name: mail
-#         subPath: logs
-#     readinessProbe:
-#       httpGet:
-#         path: /metrics
-#         port: 9154
-#       initialDelaySeconds: 5
-#   - name: postfix-logs
-#     imagePullPolicy: Always
-#     image: alpine:latest
-#     args:
-#     - sleep 15s; tail /var/log/mail.log -f | grep -v "connect from localhost\[127\.0\.0\.1\]\|lost connection after EHLO from localhost\[127\.0\.0\.1\]"
-#     command:
-#     - sh
-#     - -c
-#     volumeMounts:
-#       - mountPath: /var/log/
-#         name: mail
-#         subPath: logs
 
 deployment:
   labels: {}
@@ -170,7 +135,6 @@ config:
   postfix: {}
     # e.g.
     # myhostname: "postfix"
-    # maillog_file: /var/log/mail.log # Enable this for metrics
     # smtp_tls_security_level: "encrypt"
   opendkim: {}
     # e.g.

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -27,6 +27,8 @@ metrics:
   image: ""
   #This is what https://github.com/kumina/postfix_exporter is expecting, so setting as default
   maillog: /var/log/mail.log
+  logrotate:
+    enabled: true
 
 # Tell helm to restart (recreate) pods on every deploy. Setting this to true will inject
 # `date/deploy-date: <timestamp>` annotation into pod specification for StateFulset. This

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -91,10 +91,6 @@ extraContainers: []
 #     volumeMounts:
 #       - mountPath: /var/spool/postfix
 #         name: mail
-#       - mountPath: /var/spool/postfix/private
-#         name: private
-#       - mountPath: /var/spool/postfix/public
-#         name: public
 #       - mountPath: /var/log/
 #         name: logs
 #     readinessProbe:
@@ -133,9 +129,11 @@ container:
   postfix:
     securityContext: {}
 
-# Auto-generate certificates for the server and mount them into Postfix volume
 certs:
+  # Auto-generate certificates for the server and mount them into Postfix volume
   create: false
+  # Provide existing cert
+  exising: false
 
 # Define data which should be stored in a Secret
 # (and shared with the pod as environment variables)

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -65,16 +65,6 @@ extraInitContainers: []
 extraEnv: []
 extraContainers: []
 #Enable to following blocks for metrics
-
-# extraVolumeMounts: 
-# - name: logs
-#   mountPath: /var/log/
-#   readOnly: false
-
-# extraVolumes:
-#   - name: logs
-#     emptyDir: {}
-
 # extraContainers: |
 #   - name: exporter
 #     imagePullPolicy: Always
@@ -91,8 +81,10 @@ extraContainers: []
 #     volumeMounts:
 #       - mountPath: /var/spool/postfix
 #         name: mail
+#         subPath: spool
 #       - mountPath: /var/log/
-#         name: logs
+#         name: mail
+#         subPath: logs
 #     readinessProbe:
 #       httpGet:
 #         path: /metrics
@@ -108,7 +100,8 @@ extraContainers: []
 #     - -c
 #     volumeMounts:
 #       - mountPath: /var/log/
-#         name: logs
+#         name: mail
+#         subPath: logs
 
 deployment:
   labels: {}


### PR DESCRIPTION
Opening this now cause I am working on other tasks now. Will probably return to work on this more in the future., but I wanted to put this out to see if y'all liked it and wanted to use it. Def can be improved on.

Using this for metrics image: https://github.com/fpm-git/postfix_exporter
Made one modification to it, read log file from start, not end. This way we can have metrics after a redeploy.
There is no public image for the base repo, so if you use this you need to make one.

In order for this to work, smtp log needs to be written to file, so that the exporter can read it.
But we still want logs sent to stdout, for users and log stacks. Hence the postfix-logs container.
Ok, but now you need to manage the log files. Hence the logrotate container.