### PR TITLE
For Microsoft 365 use ,

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simple postfix relay host ("postfix null client") for your Docker containers. Ba
   * [Postfix-specific options](#postfix-specific-options)
     * [RELAYHOST, RELAYHOST_USERNAME and RELAYHOST_PASSWORD](#relayhost-relayhost_username-and-relayhost_password)
     * [POSTFIX_smtp_tls_security_level](#postfix_smtp_tls_security_level)
-    * [XOAUTH2_CLIENT_ID, XOAUTH2_SECRET, XOAUTH2_INITIAL_ACCESS_TOKEN and XOAUTH2_INITIAL_REFRESH_TOKEN](#xoauth2_client_id-xoauth2_secret-xoauth2_initial_access_token-and-xoauth2_initial_refresh_token)
+    * [XOAUTH2_CLIENT_ID, XOAUTH2_SECRET, XOAUTH2_INITIAL_ACCESS_TOKEN, XOAUTH2_INITIAL_REFRESH_TOKEN and XOAUTH2_TOKEN_ENDPOINT ](#xoauth2_client_id-xoauth2_secret-xoauth2_initial_access_token-xoauth2_initial_refresh_token-and-xoauth2_token_endpoint)
     * [MASQUERADED_DOMAINS](#masqueraded_domains)
     * [SMTP_HEADER_CHECKS](#smtp_header_checks)
     * [POSTFIX_myhostname](#postfix_myhostname)
@@ -170,6 +170,7 @@ To change the log format, set the (unsurprisingly named) variable `LOG_FORMAT=js
 * `XOAUTH2_SECRET` = OAuth2 secret used when configured as a relayhost.
 * `XOAUTH2_INITIAL_ACCESS_TOKEN` = Initial OAuth2 access token.
 * `XOAUTH2_INITIAL_REFRESH_TOKEN` = Initial OAuth2 refresh token.
+* `XOAUTH2_TOKEN_ENDPOINT` = Token endpoint provided four your XOAUTH App , GMail use : https://accounts.google.com/o/oauth2/token
 * `SMTPD_SASL_USERS` = Users allow to send mail (ex: user1:pass1,user2:pass2,...)
 * `MASQUERADED_DOMAINS` = domains where you want to masquerade internal hosts
 * `SMTP_HEADER_CHECKS`= Set to `1` to enable header checks of to a location of the file for header checks
@@ -214,7 +215,7 @@ Define relay host TLS connection level. See [smtp_tls_security_level](http://www
 
 This level defines how the postfix will connect to your upstream server.
 
-#### `XOAUTH2_CLIENT_ID`, `XOAUTH2_SECRET`, `XOAUTH2_INITIAL_ACCESS_TOKEN` and `XOAUTH2_INITIAL_REFRESH_TOKEN`
+#### `XOAUTH2_CLIENT_ID`, `XOAUTH2_SECRET`, `XOAUTH2_INITIAL_ACCESS_TOKEN`, `XOAUTH2_INITIAL_REFRESH_TOKEN` and `XOAUTH2_TOKEN_ENDPOINT`
 
 > Note: These parameters are used when `RELAYHOST` and `RELAYHOST_USERNAME` are provided.
 
@@ -222,6 +223,7 @@ These parameters allow you to configure a relayhost that requires (or recommends
 
 * `XOAUTH2_CLIENT_ID` and  `XOAUTH2_SECRET` are the [OAuth2 client credentials](#oauth2-client-credentials-gmail).
 * `XOAUTH2_INITIAL_ACCESS_TOKEN` and `XOAUTH2_INITIAL_REFRESH_TOKEN` are the [initial access token and refresh tokens](#obtain-initial-access-token-gmail).
+* `XOAUTH2_TOKEN_ENDPOINT` is mandatory for Microsoft 365 use, sasl-xoauth2 will use Gmail URL if it is not provided.
    These values are only  required to initialize the token file `/var/spool/postfix/xoauth2-tokens/$RELAYHOST_USERNAME`.
 
 Example:

--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -285,13 +285,14 @@ postfix_setup_relayhost() {
 postfix_setup_xoauth2_pre_setup() {
 	file_env 'XOAUTH2_CLIENT_ID'
 	file_env 'XOAUTH2_SECRET'
-	if [ -n "$XOAUTH2_CLIENT_ID" ] && [ -n "$XOAUTH2_SECRET" ]; then
+	if [ -n "$XOAUTH2_CLIENT_ID" ] || [ -n "$XOAUTH2_SECRET" ]; then
 		cat <<EOF > /etc/sasl-xoauth2.conf
 {
   "client_id": "${XOAUTH2_CLIENT_ID}",
   "client_secret": "${XOAUTH2_SECRET}",
   "log_to_syslog_on_failure": "${XOAUTH2_SYSLOG_ON_FAILURE:-no}",
-  "log_full_trace_on_failure": "${XOAUTH2_FULL_TRACE:-no}"
+  "log_full_trace_on_failure": "${XOAUTH2_FULL_TRACE:-no}",
+  "token_endpoint": "${XOAUTH2_TOKEN_ENDPOINT:-https://accounts.google.com/o/oauth2/token}"
 }
 EOF
 
@@ -324,7 +325,7 @@ EOF
 
 postfix_setup_xoauth2_post_setup() {
 	local other_plugins
-	if [ -n "$XOAUTH2_CLIENT_ID" ] && [ -n "$XOAUTH2_SECRET" ]; then
+	if [ -n "$XOAUTH2_CLIENT_ID" ] || [ -n "$XOAUTH2_SECRET" ]; then
 		do_postconf -e 'smtp_sasl_security_options='
 		do_postconf -e 'smtp_sasl_mechanism_filter=xoauth2'
 		do_postconf -e 'smtp_tls_session_cache_database=lmdb:${data_directory}/smtp_scache'


### PR DESCRIPTION
In case of Microsoft 365 smartrelay : 
$XOAUTH2_CLIENT_ID" can't be mandatory.
$XOAUTH2_TOKEN_ENDPOINT parameter added.
If the application will be restricted to one tenant the token edpoint is neened 

