### PR TITLE
fix: STARTTLS command not implemented

### DIFF
--- a/helm/mail/templates/configmap.yaml
+++ b/helm/mail/templates/configmap.yaml
@@ -20,6 +20,8 @@ data:
   _enable_tls.sh: |
     #!/usr/bin/env bash
     set -e
+    do_postconf -e 'smtp_use_tls=yes'
+    do_postconf -e 'smtp_tls_note_starttls_offer=yes'
     do_postconf -e 'smtpd_use_tls=yes'
     do_postconf -e 'smtpd_tls_note_starttls_offer=yes'
     do_postconf -e 'smtpd_tls_cert_file=/var/run/certs/tls.crt'

--- a/helm/mail/templates/configmap.yaml
+++ b/helm/mail/templates/configmap.yaml
@@ -20,8 +20,8 @@ data:
   _enable_tls.sh: |
     #!/usr/bin/env bash
     set -e
-    do_postconf -e 'smtp_use_tls=yes'
-    do_postconf -e 'smtp_tls_note_starttls_offer=yes'
+    do_postconf -e 'smtpd_use_tls=yes'
+    do_postconf -e 'smtpd_tls_note_starttls_offer=yes'
     do_postconf -e 'smtpd_tls_cert_file=/var/run/certs/tls.crt'
     do_postconf -e 'smtpd_tls_key_file=/var/run/certs/tls.key'
   {{- end }}


### PR DESCRIPTION
STARTTLS command is not implemented because TLS is enabled on the outgoing instead of the incoming traffic. smtp in smtp_use_tls needs to be replaced by smtpd