### PR TITLE
fix: helm version must be semver

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Package helm chart
         uses: WyriHaximus/github-action-helm3@v3
         with:
-          exec: helm package --app-version $RELEASE_VERSION --version $RELEASE_VERSION --destination ./gh-pages helm/mail
+          exec: helm package --app-version $RELEASE_VERSION --version "${RELEASE_VERSION#v}" --destination ./gh-pages helm/mail
 
       - name: Create helm chart index
         uses: WyriHaximus/github-action-helm3@v3


### PR DESCRIPTION
As noted in https://helm.sh/docs/topics/charts/#the-chartyaml-file, a helm chart's version must be semver 2.0.0.

Since semver 2.0.0 strictly prescribes the "{major}.{minor}.{patch}" format, the shell string interpolation is used to remove the `v` prefix.