### PR TITLE
Install procps on debian

### DIFF
--- a/build-scripts/postfix-install.sh
+++ b/build-scripts/postfix-install.sh
@@ -25,7 +25,7 @@ do_ubuntu() {
     apt-get install -y libsasl2-modules sasl2-bin
     apt-get install -y postfix
     apt-get install -y opendkim
-    apt-get install -y ca-certificates tzdata supervisor rsyslog bash opendkim-tools curl libcurl4 libjsoncpp25 sasl2-bin postfix-lmdb logrotate cron net-tools ${RELEASE_SPECIFIC_PACKAGES}
+    apt-get install -y ca-certificates tzdata supervisor rsyslog bash opendkim-tools curl libcurl4 libjsoncpp25 sasl2-bin postfix-lmdb procps logrotate cron net-tools ${RELEASE_SPECIFIC_PACKAGES}
     apt-get clean
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*    
 }


### PR DESCRIPTION
Kubernetes `startupProbe` uses `ps` to check if components are running.

`ps` is not present in the image, triggering a pod restart loop.