### PR TITLE
Fix ServiceMonitor selector

### DIFF
--- a/helm/mail/templates/service-monitor.yaml
+++ b/helm/mail/templates/service-monitor.yaml
@@ -23,7 +23,6 @@ spec:
     - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ $chart }}
-      prometheus: unknown
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The selector for the ServiceMonitor currently will not match the underlying service:

```yaml
selector:
    matchLabels:
      app.kubernetes.io/instance: {{ $chart }}
      prometheus: unknown
```

1. `app.kubernetes.io/instance: {{ $chart }}` will only work if the release is named `mail`, because `$chart` is hard-coded to that value here. But that's not always the case.
1. `prometheus: unknown` will cause this to never match because this label isn't applied to the underlying service (unless it is explicitly set in the values provided the helm chart). 

Fixes #162 