### PR TITLE
Generate dynamic `myhostname` for each pod

### DIFF
--- a/helm/mail/templates/hostname-script.yaml
+++ b/helm/mail/templates/hostname-script.yaml
@@ -1,0 +1,20 @@
+{{- $chart := "mail" -}}
+{{- $fullName := include (print $chart ".fullname") . -}}
+{{- $labels := include (print $chart ".labels") . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hostname-init
+  labels:
+    {{- $labels | nindent 4 }}
+data:
+  set_hostname.sh: |
+    #!/usr/bin/env bash
+
+    # Load the hostname from the file
+    if [ -f /var/worker-ip/hostname.txt ]; then
+        export POSTFIX_myhostname=$(cat /var/worker-ip/hostname.txt)
+    fi
+
+    # Execute the main container command
+    /scripts/run.sh

--- a/helm/mail/templates/service-monitor.yaml
+++ b/helm/mail/templates/service-monitor.yaml
@@ -24,6 +24,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ $chart }}
-      prometheus: unknown
 {{- end -}}
 {{- end -}}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -48,13 +48,30 @@ spec:
       {{ with .Values.affinity }}affinity: {{- toYaml . | nindent 8 }} {{- end }}
       {{ with .Values.tolerations }}tolerations: {{- toYaml . | nindent 8 }} {{- end }}
 
-      {{- if .Values.extraInitContainers }}
+      {{- if or .Values.extraInitContainers .Values.GenerateHostName.enabled }}
       #
       # Init containers
       #
       initContainers:
-      {{- tpl .Values.extraInitContainers . | nindent 6 }}
       {{- end }}
+      {{- if .Values.extraInitContainers}}
+      {{- tpl .Values.extraInitContainers . | nindent 6 }}
+      {{- else if .Values.GenerateHostName.enabled }}
+        - name: get-public-ip
+          image: curlimages/curl:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              IP=$(curl http://ipinfo.io/ip);
+              PREFIX={{- .Values.GenerateHostName.prefix -}};
+              DOMAIN={{- .Values.GenerateHostName.domain -}};
+              echo "${PREFIX}-${IP}.${DOMAIN}" > /var/worker-ip/hostname.txt;
+          volumeMounts:
+            - mountPath: "/var/worker-ip"
+              name: {{ $fullName | quote }}
+              subPath: ip
+      {{- end }}
+
 
       # Allow up to 2 minutes for Postfix to flush / empty the queue  before shutting down the container
       terminationGracePeriodSeconds: 120
@@ -81,6 +98,13 @@ spec:
             {{- if .Values.lifecycle.postStart }}
             postStart: {{- toYaml .Values.lifecycle.postStart | nindent 14 }}
             {{- end }}
+          {{- if .Values.GenerateHostName.enabled }}
+          env: 
+            - name: POSTFIX_myhostname
+              valueFrom:
+                fieldRef:
+                  fieldPath: "/var/worker-ip/hostname.txt"
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ $fullName | quote }}
@@ -132,6 +156,11 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.extraVolumeMounts }}{{- toYaml .Values.extraVolumeMounts | nindent 12 }}{{ end }}
+            {{- if .Values.GenerateHostName.enabled }}
+            - mountPath: "/var/worker-ip"
+              name: {{ $fullName | quote }}
+              subPath: ip
+            {{- end }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
         {{- if .Values.metrics.enabled }}
         - name: exporter

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -63,6 +63,7 @@ spec:
           args:
             - >
               IP=$(curl http://ipinfo.io/ip);
+              IP=$(echo "$IP" | tr '.' '-')
               PREFIX={{- .Values.GenerateHostName.prefix -}};
               DOMAIN={{- .Values.GenerateHostName.domain -}};
               echo "${PREFIX}-${IP}.${DOMAIN}" > /var/worker-ip/hostname.txt;

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -99,11 +99,7 @@ spec:
             postStart: {{- toYaml .Values.lifecycle.postStart | nindent 14 }}
             {{- end }}
           {{- if .Values.GenerateHostName.enabled }}
-          env: 
-            - name: POSTFIX_myhostname
-              valueFrom:
-                fieldRef:
-                  fieldPath: "/var/worker-ip/hostname.txt"
+          command: ["/var/generate-hostname/set_hostname.sh"]
           {{- end }}
           envFrom:
             - configMapRef:
@@ -160,6 +156,8 @@ spec:
             - mountPath: "/var/worker-ip"
               name: {{ $fullName | quote }}
               subPath: ip
+            - mountPath: "/var/generate-hostname"
+              name: hostname-init
             {{- end }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
         {{- if .Values.metrics.enabled }}
@@ -245,6 +243,12 @@ spec:
         - name: metrics-config-scripts
           configMap:
             name: {{ print $fullName "-scripts" | quote }}
+            defaultMode: 0777
+        {{- end }}
+        {{- if .Values.GenerateHostName.enabled }}
+        - name: hostname-init
+          configMap:
+            name: hostname-init
             defaultMode: 0777
         {{- end }}
         {{- if .Values.extraVolumes }}{{- toYaml .Values.extraVolumes | nindent 8 }}{{ end }}

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -151,6 +151,13 @@ mountSecret:
     #   < redacted >
     #   -----END RSA PRIVATE KEY-----
 
+
+# if the following is true, config.prefix.myhostname should not be set
+GenerateHostName:
+  enabled: false
+  domain: example.com
+  prefix: smtp
+
 config:
   general: {}
     # e.g.


### PR DESCRIPTION
To comply with ISP's request, and according to [smtp best practices](https://mailtrap.io/blog/ptr-records/), I would like to have dynamic hostnames for my smtp servers.

Simply using the `HOSTNAME` env var is not helpful as by default is something like `mail-0`. Looked briefly into hacking it to be closer to what I want, but decided it was not worth it.

I have made an attempt at this, I know it is not the best. But it works and I bet if y'all like it you can do it better. 

By setting the following in the values.
```
# if the following is true, config.prefix.myhostname should not be set
GenerateHostName:
  enabled: true
  domain: example.com
  prefix: smtp
```

The following hostname will be used by each pod, and they will be unique and be built off of the public IP of that host.
smtp-###-###-###-###.example.com

We have tested this out and it is fully working. Have it in use right now and monitoring.

I hope that this can be useful.