### PR TITLE
Fix sasldb with SMTPD_SASL_USERS  env variable

### DIFF
--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -430,6 +430,7 @@ EOF
 
 		[ -f /etc/sasldb2 ] && chown postfix:postfix /etc/sasldb2
 		[ -f /etc/sasl2/sasldb2 ] && chown postfix:postfix /etc/sasl2/sasldb2
+  		debug 'Sasldb configured'
 	fi
 }
 


### PR DESCRIPTION
We encountered an issue where the script common-run.sh would fail if the SMTPD_SASL_USERS environment variable was defined. The failure occurred immediately after displaying the "Enable smtpd sasl auth" message, preventing the container from starting correctly.

The root cause was traced to a conditional check for the existence of the /etc/sasl2/sasldb2 file. When the file did not exist, the subsequent `chown` operation was skipped as intended, but the script would still fail due to an undefined behavior in the shell context.

The addition of a debug message "Sasldb configured" before the closing `fi` statement has resolved the issue. This change appears to stabilize the script execution, allowing the container to start as expected.

While the underlying cause is not fully understood and warrants further investigation, this commit serves as a temporary workaround to ensure functionality in environments where SMTPD_SASL_USERS is set.