### PR TITLE
Expand volumeClaimTemplates spec

### DIFF
--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -221,7 +221,9 @@ spec:
         {{- if .Values.extraVolumes }}{{- toYaml .Values.extraVolumes | nindent 8 }}{{ end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ $fullName }}
         namespace: {{ .Release.Namespace }}
       spec:


### PR DESCRIPTION
Use the full volumeClaimTemplates spec to avoid manifest diffs when using ServerSideApply/Diff.

Example:

<img width="412" alt="image" src="https://github.com/bokysan/docker-postfix/assets/6215635/bd247576-4ce3-4671-9b3f-620744628794">
