### PR TITLE
autoscaling.apiVersion

### DIFF
--- a/helm/mail/templates/hpa.yaml
+++ b/helm/mail/templates/hpa.yaml
@@ -3,7 +3,7 @@
 {{- $fullName := include (print $chart ".fullname") . -}}
 {{- $labels := include (print $chart ".labels") . -}}
 {{- $kind := "StatefulSet" -}}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $fullName | quote }}

--- a/helm/mail/templates/hpa.yaml
+++ b/helm/mail/templates/hpa.yaml
@@ -3,7 +3,11 @@
 {{- $fullName := include (print $chart ".fullname") . -}}
 {{- $labels := include (print $chart ".labels") . -}}
 {{- $kind := "StatefulSet" -}}
-apiVersion: {{ .Values.autoscaling.apiVersion }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $fullName | quote }}

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -39,7 +39,7 @@ metrics:
     annotations: {}
   port: 9154
   path: /metrics
-  image: 
+  image:
     repository: "boky/postfix-exporter"
     tag: "latest"
 
@@ -95,6 +95,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
   labels: {}
   annotations: {}
+  apiVersion: "autoscaling/v2beta1"
 
 nodeSelector: {}
 tolerations: []
@@ -184,7 +185,7 @@ dns:
     # - 8.8.8.8
     # - 8.8.4.4
   searches: ""
-  # searches: 
+  # searches:
   # - "default.svc.cluster.local"
   # - "svc.cluster.local"
   # - "cluster.local"

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -95,7 +95,6 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
   labels: {}
   annotations: {}
-  apiVersion: "autoscaling/v2beta1"
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
apiVersion: "autoscaling/v2beta1" is deprecated, adding value for overriding api version, fore example apiVersion: autoscaling/v2