### PR TITLE
Add missing appProtocol

### DIFF
--- a/helm/mail/templates/service.yaml
+++ b/helm/mail/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: smtp
       {{ if eq .Values.service.type "NodePort" }}nodePort: {{ .Values.service.nodePort }}{{ end }}
-      {{ if .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
+      {{ if and (semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion) .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
   selector:
     {{- $selectorLabels | nindent 4 }}
 {{- if .Values.headlessService.enabled }}
@@ -47,7 +47,7 @@ spec:
       targetPort: smtp
       protocol: TCP
       name: smtp
-      {{ if .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
+      {{ if and (semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion) .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
   selector:
     {{- $selectorLabels | nindent 4 }} 
 {{- end -}}

--- a/helm/mail/templates/service.yaml
+++ b/helm/mail/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
       protocol: TCP
       name: smtp
       {{ if eq .Values.service.type "NodePort" }}nodePort: {{ .Values.service.nodePort }}{{ end }}
+      {{ if .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
   selector:
     {{- $selectorLabels | nindent 4 }}
 {{- if .Values.headlessService.enabled }}
@@ -46,6 +47,7 @@ spec:
       targetPort: smtp
       protocol: TCP
       name: smtp
+      {{ if .Values.service.appprotocol }}appProtocol: {{ .Values.service.appprotocol }}{{ end }}
   selector:
     {{- $selectorLabels | nindent 4 }} 
 {{- end -}}


### PR DESCRIPTION
Hey, ive encountered strange behavior inside and ipv6 eks cluster and traced it to set the right protocol when using (mandatory) (m)tls.
if you do not do this, the ingress will wait for your first input and the welcome header wont get transmitted to the sender. didnt open an issue as this fix was pretty obvious