### PR TITLE
Delete duplicate logrotate config for `mail.log`

### DIFF
--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -54,6 +54,13 @@ rsyslog_log_format() {
 	sed -i -E "s/<log-format>/${log_format}/" /etc/rsyslog.conf
 }
 
+logrotate_remove_duplicate_mail_log() {
+	if egrep -q '^/var/log/mail.log' /etc/logrotate.d/logrotate.conf; then
+		info "Removing /var/log/mail.log from /etc/logrotate.d/rsyslog"
+		sed -i -E '/^\/var\/log\/mail.log/d' /etc/logrotate.d/rsyslog
+	fi
+}
+
 anon_email_log() {
 	local anon_email="${ANONYMIZE_EMAILS}"
 	if [[ "${anon_email}" == "true" || "${anon_email}" == "1" || "${anon_email}" == "yes" || "${anon_email}" == "y" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,6 +9,7 @@ announce_startup                        # Print startup banner
 setup_timezone                          # Check if we need to configure the container timezone
 check_environment_sane                  # Check if the the environment is sane
 rsyslog_log_format                      # Setup rsyslog output format
+logrotate_remove_duplicate_mail_log     # Remove duplicate logrotate mail.log entry
 anon_email_log                          # Setup email anonymizer
 setup_conf                              # Copy over files from /etc/postfix.template to /etc/postfix, if the user mounted the folder manually
 reown_folders                           # Make and reown /var/spool/postfix/ folders


### PR DESCRIPTION
Fixes https://github.com/bokysan/docker-postfix/issues/212. This appears to be a common strategy: https://github.com/docker-mailserver/docker-mailserver/blob/c29fe3ff0bc888016720536228878b3f19131056/Dockerfile#L259.

### Before
```shell
root@postfix-mail-0:/tmp# /etc/cron.daily/logrotate
error: rsyslog:1 duplicate log entry for /var/log/mail.log
error: found error in file rsyslog, skipping
root@postfix-mail-0:/tmp# echo $?
1
root@postfix-mail-0:/tmp# cat /etc/logrotate.d/logrotate.conf
/var/log/mail.log {
    copytruncate
    rotate 1
    monthly
    minsize 1M
    compress
    missingok
    notifempty
    dateext
    olddir /var/log/
    maxage 90
}
```

### After
```
root@postfix-mail-0:/tmp# if egrep -q '^/var/log/mail.log' /etc/logrotate.d/logrotate.conf; then
        echo "Removing /var/log/mail.log from /etc/logrotate.d/rsyslog"
        sed -i -E '/^\/var\/log\/mail.log/d' /etc/logrotate.d/rsyslog
fi
Removing /var/log/mail.log from /etc/logrotate.d/rsyslog
root@postfix-mail-0:/tmp# /etc/cron.daily/logrotate
root@postfix-mail-0:/tmp# echo $?
0
root@postfix-mail-0:/tmp# cat /etc/logrotate.d/rsyslog
/var/log/syslog
/var/log/kern.log
/var/log/auth.log
/var/log/user.log
/var/log/cron.log
{
        rotate 4
        weekly
        missingok
        notifempty
        compress
        delaycompress
        sharedscripts
        postrotate
                /usr/lib/rsyslog/rsyslog-rotate
        endscript
}
```