### PR TITLE
Don't enable smtputf8 when running on alpine on container restart

### DIFF
--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -258,7 +258,7 @@ postfix_disable_utf8() {
 	if [[ -f /etc/alpine-release ]] && [[ "${smtputf8_enable}" == "yes" ]]; then
 		debug "Running on Alpine. Setting ${emphasis}smtputf8_enable${reset}=${emphasis}no${reset}, as Alpine does not have proper libraries to handle UTF-8"
 		do_postconf -e smtputf8_enable=no
-	elif [[ "${smtputf8_enable}" == "no" ]]; then
+	elif [[ ! -f /etc/alpine-release ]] && [[ "${smtputf8_enable}" == "no" ]]; then
 		debug "Running on non-Alpine system. Setting ${emphasis}smtputf8_enable${reset}=${emphasis}yes${reset}."
 		do_postconf -e smtputf8_enable=yes
 	fi


### PR DESCRIPTION
`postfix_disable_utf8` checks if its running on alpine and if so, disables smtputf8.

However, the check is wrong. Consider this scenario:

1. alpine container is created, smtputf8_enable is set to `no` using `-e POSTFIX_smtputf8_enable=no`
2. container is restarted. Now the `elif` branch is taken and smtputf8 is actually enabled on alpine.
3. Due to the set environment var, it is set to `no` again, so no harm done.

We actually encountered this on our system:

```
★★★★★ POSTFIX STARTING UP (alpine) ★★★★★
‣ NOTE  System accounts: postfix=100:101, opendkim=102:103. Careful when switching distros.
‣ INFO  Not setting any timezone for the container
‣ DEBUG /tmp writable.
‣ INFO  Using plain log format for rsyslog.
‣ NOTE  Emails in the logs will not be anonymized. Set ANONYMIZE_EMAILS to enable this feature.
‣ DEBUG Reowning root: /var/spool/postfix/
‣ DEBUG Reowning root: /var/spool/postfix/pid/
‣ DEBUG Reowning postfix:postdrop /var/spool/postfix/private/
‣ DEBUG Reowning postfix:postdrop /var/spool/postfix/public/
‣ INFO  Preparing files for Postfix chroot:
        '/etc/localtime' -> '/var/spool/postfix/etc/localtime'
        '/etc/nsswitch.conf' -> '/var/spool/postfix/etc/nsswitch.conf'
        '/etc/resolv.conf' -> '/var/spool/postfix/etc/resolv.conf'
        '/etc/services' -> '/var/spool/postfix/etc/services'
        '/etc/hosts' -> '/var/spool/postfix/etc/hosts'
        '/etc/passwd' -> '/var/spool/postfix/etc/passwd'
‣ DEBUG No upgrade of hashes needed needed.
‣ DEBUG Running on non-Alpine system. Setting smtputf8_enable=yes.
...
```

This PR adds an additional check for non-existence of `/etfc/alpine-release` to the `elif` branch to make sure that branch is only taken in non-alpine containers.