### PR TITLE
Allow cert secret rename

### DIFF
--- a/helm/mail/templates/_helpers.tpl
+++ b/helm/mail/templates/_helpers.tpl
@@ -79,7 +79,7 @@ configmap.reloader.stakater.com/reload: "{{ include "mail.fullname" . }}"
 {{/*
 Return the secret containing HTTPS/TLS certificates
 */}}
-{{- define "tls.SecretName" -}}
+{{- define "tls.secretName" -}}
 {{- $secretName := .Values.certs.existingSecret -}}
 {{- if $secretName -}}
     {{- printf "%s" (tpl $secretName .) -}}  # Use '.' for context, not '$'

--- a/helm/mail/templates/_helpers.tpl
+++ b/helm/mail/templates/_helpers.tpl
@@ -76,3 +76,14 @@ checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . |
 configmap.reloader.stakater.com/reload: "{{ include "mail.fullname" . }}"
 {{- end -}}
 
+{{/*
+Return the secret containing HTTPS/TLS certificates
+*/}}
+{{- define "tls.SecretName" -}}
+{{- $secretName := .Values.certs.existingSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" (tpl $secretName .) -}}  # Use '.' for context, not '$'
+{{- else -}}
+    {{- printf "%s-cert" (include "smtp-relay-mail-certs" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/mail/templates/_helpers.tpl
+++ b/helm/mail/templates/_helpers.tpl
@@ -84,6 +84,6 @@ Return the secret containing HTTPS/TLS certificates
 {{- if $secretName -}}
     {{- printf "%s" (tpl $secretName .) -}}  # Use '.' for context, not '$'
 {{- else -}}
-    {{- printf "%s-cert" (include "smtp-relay-mail-certs" .) -}}
+    {{- printf "%s" (include "smtp-relay-mail-certs" .) -}}
 {{- end -}}
 {{- end -}}

--- a/helm/mail/templates/secret-cert.yaml
+++ b/helm/mail/templates/secret-cert.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: {{ $fullName }}-certs
+  name: {{ .Values.certs.name }}
   labels:
     {{- $labels | nindent 4 }}
   annotations:

--- a/helm/mail/templates/secret-cert.yaml
+++ b/helm/mail/templates/secret-cert.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: {{ .Values.certs.name }}
+  name: {{ include "tls.secretName" . }}
   labels:
     {{- $labels | nindent 4 }}
   annotations:

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -195,7 +195,7 @@ spec:
             defaultMode: 0755
         - name: certs
           secret:
-            secretName: {{ include "keycloak.tlsSecretName" . }}
+            secretName: {{ include "tls.secretName" . }}
         {{- end }}
         # Socket directories
         {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -195,7 +195,7 @@ spec:
             defaultMode: 0755
         - name: certs
           secret:
-            secretName: {{ .Values.certs.name }}
+            secretName: {{ include "keycloak.tlsSecretName" . }}
         {{- end }}
         # Socket directories
         {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}

--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -195,7 +195,7 @@ spec:
             defaultMode: 0755
         - name: certs
           secret:
-            secretName: {{ $fullName }}-certs
+            secretName: {{ .Values.certs.name }}
         {{- end }}
         # Socket directories
         {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -129,6 +129,8 @@ certs:
   create: false
   # Provide existing cert
   existing: false
+  # Provide Cert Name
+  name: "smtp-relay-mail-certs"
 
 # Define data which should be stored in a Secret
 # (and shared with the pod as environment variables)

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -129,8 +129,8 @@ certs:
   create: false
   # Provide existing cert
   existing: false
-  # Provide Cert Name
-  name: "smtp-relay-mail-certs"
+  # Provide existing secret name
+  existingSecret: ""
 
 # Define data which should be stored in a Secret
 # (and shared with the pod as environment variables)


### PR DESCRIPTION
This would be to allow the renaming of the Cert Secret. cause it can be useful when you reflect certs from cert manager.