### PR TITLE
added ability to define resource options for the metrics exporter

### DIFF
--- a/helm/mail/templates/statefulset.yaml
+++ b/helm/mail/templates/statefulset.yaml
@@ -175,6 +175,7 @@ spec:
             initialDelaySeconds: 5
             failureThreshold: 30
             periodSeconds: 10
+          resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
         {{- end }}
         {{- if .Values.extraContainers }}
         {{- tpl .Values.extraContainers $root | nindent 8 }}

--- a/helm/mail/values.yaml
+++ b/helm/mail/values.yaml
@@ -64,6 +64,15 @@ metrics:
           maxage 90
       }
 
+  resources: {}
+  # If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 # Tell helm to restart (recreate) pods on every deploy. Setting this to true will inject
 # `date/deploy-date: <timestamp>` annotation into pod specification for StateFulset. This


### PR DESCRIPTION
Currently, there is no way to set the `resources` for the `postfix-exporter` via `values.yaml` in the Helm chart. This PR makes the exporter resources configurable via `values.yaml` where I added a `resources` field inside the existing `metrics` object.

```yaml
metrics:
  enabled: false
  ...
  resources: {}
```